### PR TITLE
Fix lost type registrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ For more refer to <https://issues.apache.org/jira/browse/FLINK-13414>.
 ```bash
 rm $FLINK_HOME/lib/flink-scala*.jar
 
-wget https://repo1.maven.org/maven2/pl/touk/flink-scala_2.13/1.1.6/flink-scala_2.13-1.1.6-assembly.jar -O $FLINK_HOME/lib/flink-scala_2.13-1.1.6-assembly.jar
+wget https://repo1.maven.org/maven2/pl/touk/flink-scala_2.13/1.2.0/flink-scala_2.13-1.2.0-assembly.jar -O $FLINK_HOME/lib/flink-scala_2.13-1.2.0-assembly.jar
 ```
 
 ## Using as a lib (probably only sufficient when child-first classloading is enabled on flink)
 
 ```scala
-libraryDependencies += "pl.touk" %% "flink-scala" % "1.1.6"
+libraryDependencies += "pl.touk" %% "flink-scala" % "1.2.0"
 ```
 
 ## Pre-built Flink images
@@ -28,9 +28,9 @@ We provide pre-built Docker images for Flink with Scala 2.13 on [Docker Hub](htt
 
 ## Publishing
 
-1. Change version in _build.sbt_, commit changes
+1. Change version in _version.sbt_, commit changes
 2. Add version tag (`git tag v...`)
 3. Push changes to GitHub 
 4. Manually run the [_Publish_ workflow in GitHub Actions](https://github.com/TouK/flink-scala/actions/workflows/publish.yml)
-5. Change version to a `-SNAPSHOT` version in build.sbt
+5. Change version to a `-SNAPSHOT` version in version.sbt
 6. Commit and push changes

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,6 @@
 import sbtassembly.MergeStrategy
 
 name := "flink-scala"
-version := "1.1.6"
 
 val scala213 = "2.13.18"
 

--- a/build.sbt
+++ b/build.sbt
@@ -39,13 +39,15 @@ lazy val publishSettings = Seq(
       "scm:git@github.com:TouK/flink-scala.git"
     )
   ),
-  developers := List(
-    Developer(
-      id = "TouK",
-      name = "TouK",
-      email = "",
-      url = url("https://touk.pl")
-    )
+  pomExtra := List(
+    <developers>
+      <developer>
+        <name>Nussknacker Team</name>
+        <email>info@nussknacker.io</email>
+        <organization>Nussknacker</organization>
+        <organizationUrl>https://nussknacker.io</organizationUrl>
+      </developer>
+    </developers>
   ),
 )
 
@@ -53,9 +55,9 @@ lazy val root = (project in file("."))
   .settings(
     name := "flink-scala",
     organization := "pl.touk",
-    organizationName := "TouK",
-    organizationHomepage := Some(url("https://touk.pl/")),
-    licenses := Seq("Apache 2" -> url("http://www.apache.org/licenses/LICENSE-2.0.txt")),
+    organizationName := "Nussknacker",
+    organizationHomepage := Some(url("https://nussknacker.io")),
+    licenses := List(License.Apache2),
     homepage := Some(url("https://github.com/TouK/flink-scala")),
     libraryDependencies ++= Seq(
       "org.scala-lang" % "scala-library" % scalaVersion.value,

--- a/src/main/scala/org/apache/flink/api/java/typeutils/runtime/kryo/FlinkChillPackageRegistrar.scala
+++ b/src/main/scala/org/apache/flink/api/java/typeutils/runtime/kryo/FlinkChillPackageRegistrar.scala
@@ -1,0 +1,42 @@
+package org.apache.flink.api.java.typeutils.runtime.kryo
+
+import com.esotericsoftware.kryo.Kryo
+import com.twitter.chill.java.{ArraysAsListSerializer, BitSetSerializer, InetSocketAddressSerializer, LocaleSerializer, RegexSerializer, SimpleDateFormatSerializer, SqlDateSerializer, SqlTimeSerializer, TimestampSerializer, URISerializer, UUIDSerializer}
+
+import java.net.{InetSocketAddress, URI}
+import java.sql.{Date, Time, Timestamp}
+import java.text.SimpleDateFormat
+import java.util
+import java.util.regex.Pattern
+import java.util.{Locale, PriorityQueue, UUID}
+
+/**
+ * Overwrites the original class so that we can provide higher free id
+ * to [[org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer]].
+ *
+ * We need this because our [[org.apache.flink.runtime.types.FlinkScalaKryoInstantiator]]
+ * declares more serializers than the original Chill library, and the hardcoded free id of '85' is too low.
+ *
+ * We're breaking compatibility anyway, so we also drop original registration ids.
+ */
+class FlinkChillPackageRegistrar extends ChillSerializerRegistrar {
+
+  override def registerSerializers(k: Kryo): Unit = {
+    k.register(_root_.java.util.Arrays.asList("").getClass, new ArraysAsListSerializer())
+    k.register(classOf[util.BitSet], new BitSetSerializer())
+    k.register(classOf[PriorityQueue[_]], new PriorityQueueSerializer())
+    k.register(classOf[Pattern], new RegexSerializer())
+    k.register(classOf[Date], new SqlDateSerializer())
+    k.register(classOf[Time], new SqlTimeSerializer())
+    k.register(classOf[Timestamp], new TimestampSerializer())
+    k.register(classOf[URI], new URISerializer())
+    k.register(classOf[InetSocketAddress], new InetSocketAddressSerializer())
+    k.register(classOf[UUID], new UUIDSerializer())
+    k.register(classOf[Locale], new LocaleSerializer())
+    k.register(classOf[SimpleDateFormat], new SimpleDateFormatSerializer())
+  }
+
+  // at the moment this was written our Kryo.getNextRegistrationId was returning 112
+  override def getNextRegistrationId: Int = 150
+
+}

--- a/src/main/scala/org/apache/flink/runtime/types/FlinkScalaKryoInstantiator.scala
+++ b/src/main/scala/org/apache/flink/runtime/types/FlinkScalaKryoInstantiator.scala
@@ -18,12 +18,11 @@
 package org.apache.flink.runtime.types
 
 import com.twitter.chill._
-import com.twitter.chill.java.{UnmodifiableCollectionSerializer, UnmodifiableListSerializer, UnmodifiableMapSerializer, UnmodifiableSetSerializer, UnmodifiableSortedMapSerializer, UnmodifiableSortedSetSerializer}
 import org.apache.flink.api.java.typeutils.runtime.kryo.FlinkChillPackageRegistrar
 
-import _root_.java.io.Serializable
 import scala.collection.immutable.{ArraySeq, BitSet, HashMap, HashSet, ListMap, ListSet, NumericRange, Queue, Range, SortedMap, SortedSet}
-import scala.collection.mutable.{Buffer, ListBuffer, ArraySeq => MArraySeq, BitSet => MBitSet, HashMap => MHashMap, HashSet => MHashSet, Map => MMap, Queue => MQueue, Set => MSet}
+import scala.collection.mutable
+import scala.collection.mutable.{ListBuffer, ArraySeq => MArraySeq, BitSet => MBitSet, HashMap => MHashMap, HashSet => MHashSet, Map => MMap, Queue => MQueue, Set => MSet}
 import scala.jdk.CollectionConverters._
 import scala.reflect.ClassTag
 import scala.util.matching.Regex
@@ -40,7 +39,7 @@ checks in our code base.
  * registered serializers, just the standard Kryo configured for Kryo.
  */
 class EmptyFlinkScalaKryoInstantiator extends KryoInstantiator {
-  override def newKryo = {
+  override def newKryo: KryoBase = {
     val k = new KryoBase
     k.setRegistrationRequired(false)
     k.setInstantiatorStrategy(new org.objenesis.strategy.StdInstantiatorStrategy)
@@ -75,22 +74,12 @@ object FlinkScalaKryoInstantiator extends Serializable {
 
 /** Makes an empty instantiator then registers everything */
 class FlinkScalaKryoInstantiator extends EmptyFlinkScalaKryoInstantiator {
-  override def newKryo = {
+  override def newKryo: KryoBase = {
     val k = super.newKryo
     new AllScalaRegistrar().apply(k)
-    registerUnmodifiableJavaCollectionsSerializers(k)
+    UnmodifiableJavaCollectionsRegistrar.apply(k)
     k
   }
-
-  private def registerUnmodifiableJavaCollectionsSerializers(k: KryoBase): Unit = {
-    UnmodifiableCollectionSerializer.registrar.apply(k)
-    UnmodifiableListSerializer.registrar.apply(k)
-    UnmodifiableMapSerializer.registrar.apply(k)
-    UnmodifiableSetSerializer.registrar.apply(k)
-    UnmodifiableSortedMapSerializer.registrar.apply(k)
-    UnmodifiableSortedSetSerializer.registrar.apply(k)
-  }
-
 }
 
 class ScalaCollectionsRegistrar extends IKryoRegistrar {
@@ -126,7 +115,7 @@ class ScalaCollectionsRegistrar extends IKryoRegistrar {
       // Add ListBuffer subclass before Buffer to prevent the more general case taking precedence
       .forTraversableSubclass(ListBuffer.empty[Any], isImmutable = false)
       // add mutable Buffer before Vector, otherwise Vector is used
-      .forTraversableSubclass(Buffer.empty[Any], isImmutable = false)
+      .forTraversableSubclass(mutable.Buffer.empty[Any], isImmutable = false)
       // Vector is a final class
       .forTraversableClass(Vector.empty[Any])
       .forTraversableSubclass(ListSet.empty[Any])
@@ -180,23 +169,16 @@ class JavaWrapperScala2_13Registrar extends IKryoRegistrar {
 /** Registers all the scala (and java) serializers we have */
 class AllScalaRegistrar extends IKryoRegistrar {
   def apply(k: Kryo): Unit = {
-    val col = new ScalaCollectionsRegistrar
-    col(k)
-
-    val jcol = new JavaWrapperCollectionRegistrar
-    jcol(k)
-
-    val jmap = new JavaWrapperScala2_13Registrar
-    jmap(k)
-
-    val smap = new ScalaCollectionsRegistrarCompat
-    smap(k)
+    new ScalaCollectionsRegistrar()(k)
+    new JavaWrapperCollectionRegistrar()(k)
+    new JavaWrapperScala2_13Registrar()(k)
+    new ScalaCollectionsRegistrarCompat()(k)
 
     // Register all 22 tuple serializers and specialized serializers
     ScalaTupleSerialization.register(k)
     k.forClass[Symbol](new KSerializer[Symbol] {
       override def isImmutable = true
-      def write(k: Kryo, out: Output, obj: Symbol): Unit = { out.writeString(obj.name) }
+      def write(k: Kryo, out: Output, obj: Symbol): Unit = out.writeString(obj.name)
       def read(k: Kryo, in: Input, cls: Class[Symbol]) = Symbol(in.readString)
     }).forSubclass[Regex](new RegexSerializer)
       .forClass[ClassTag[Any]](new ClassTagSerializer[Any])

--- a/src/main/scala/org/apache/flink/runtime/types/UnmodifiableJavaCollectionsRegistrar.scala
+++ b/src/main/scala/org/apache/flink/runtime/types/UnmodifiableJavaCollectionsRegistrar.scala
@@ -1,0 +1,18 @@
+package org.apache.flink.runtime.types
+
+import com.esotericsoftware.kryo.Kryo
+import com.twitter.chill.java.{IterableRegistrar, UnmodifiableCollectionSerializer, UnmodifiableListSerializer, UnmodifiableMapSerializer, UnmodifiableSetSerializer, UnmodifiableSortedMapSerializer, UnmodifiableSortedSetSerializer}
+
+/**
+ * Registrations cherry-picked from [[com.twitter.chill.java.PackageRegistrar]]
+ */
+object UnmodifiableJavaCollectionsRegistrar {
+  def apply(k: Kryo): Unit = new IterableRegistrar(
+    UnmodifiableCollectionSerializer.registrar(),
+    UnmodifiableListSerializer.registrar(),
+    UnmodifiableMapSerializer.registrar(),
+    UnmodifiableSetSerializer.registrar(),
+    UnmodifiableSortedMapSerializer.registrar(),
+    UnmodifiableSortedSetSerializer.registrar(),
+  ).apply(k)
+}

--- a/src/test/scala/org/apache/flink/api/java/typeutils/runtime/kryo/FlinkChillPackageRegistrarSpec.scala
+++ b/src/test/scala/org/apache/flink/api/java/typeutils/runtime/kryo/FlinkChillPackageRegistrarSpec.scala
@@ -1,0 +1,14 @@
+package org.apache.flink.api.java.typeutils.runtime.kryo
+
+import org.apache.flink.runtime.types.FlinkScalaKryoInstantiator
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class FlinkChillPackageRegistrarSpec extends AnyFlatSpec with Matchers {
+
+  it should "return valid next registration id" in {
+    val ourKryo = new FlinkScalaKryoInstantiator().newKryo
+    new FlinkChillPackageRegistrar().getNextRegistrationId shouldBe >= (ourKryo.getNextRegistrationId)
+  }
+
+}

--- a/src/test/scala/org/apache/flink/api/java/typeutils/runtime/kryo/KryoSerializerSpec.scala
+++ b/src/test/scala/org/apache/flink/api/java/typeutils/runtime/kryo/KryoSerializerSpec.scala
@@ -1,0 +1,25 @@
+package org.apache.flink.api.java.typeutils.runtime.kryo
+
+import org.apache.flink.api.common.serialization.SerializerConfigImpl
+import org.apache.flink.runtime.types.FlinkScalaKryoInstantiator
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class KryoSerializerSpec extends AnyFlatSpec with Matchers {
+
+  it should "now overwrite our type registrations" in {
+    val ourKryo = new FlinkScalaKryoInstantiator().newKryo
+    val flinkKryo = new KryoSerializer(classOf[TestClass], new SerializerConfigImpl()).getKryo
+
+    // Index 85 is crucial as that's what's indicated as free by Flink's own ChillSerializerRegistrar
+    for (id <- 0 until ourKryo.getNextRegistrationId) {
+      val ourRegistration = ourKryo.getRegistration(id)
+      withClue(ourRegistration) {
+        ourRegistration.getType shouldBe flinkKryo.getRegistration(id).getType
+      }
+    }
+  }
+
+  class TestClass
+
+}

--- a/version.sbt
+++ b/version.sbt
@@ -1,0 +1,1 @@
+ThisBuild / version := "1.2.0"


### PR DESCRIPTION
Fix for Flink overwriting our Kryo registrations: Flink uses `FlinkChillPackageRegistrar.getNextRegistrationId` to find out the next free id that it can use for registering new types from `KryoSerializer`, which causes our type registration to be overwritten.

I also threw in some refactoring to make PR for Flink 2 smaller.